### PR TITLE
adds BuyMatic Component for buying MATIC through Wyre

### DIFF
--- a/packages/gardens/src/components/BuyMatic.tsx
+++ b/packages/gardens/src/components/BuyMatic.tsx
@@ -1,0 +1,74 @@
+import axios from "axios";
+import {
+    Button,
+} from "@chakra-ui/react";
+import { useWeb3React } from "@web3-react/core";
+
+// TODO: could update source currency automatically based on locale
+
+function BuyMatic() {
+    const { account } = useWeb3React();
+
+    async function wyreCheckout() {
+        type WyreCheckoutParams = {
+            redirectUrl?: string;
+            failureRedirectUrl?: string;
+            dest?: string | undefined;
+        }
+        const params: WyreCheckoutParams = {
+            redirectUrl: window.location.href,
+            failureRedirectUrl: window.location.href,
+        };
+        let dest;
+        if (account) {
+            dest = `ethereum:${account}`;
+            params.dest = dest;
+        }
+        let prevReservationUrl = localStorage.getItem('shrub:buyMatic:reservationUrl');
+        const prevReservationDate = localStorage.getItem('shrub:buyMatic:reservationDate');
+        const prevReservationEndDate = prevReservationDate && new Date((new Date(prevReservationDate).getTime() + (60 * 1000 * 14)));
+        // if there is a reservation in the storage and we are within the range, use previous reservation url
+        if (prevReservationDate && prevReservationEndDate && (prevReservationEndDate > new Date()) && prevReservationUrl){
+            // go to the previously used wyre checkout link and let it redirect back to the application on success/fail
+            // reset the ethereum address in the reservation url if a user has updated it
+            if (account && dest && !prevReservationUrl.includes(account)) {
+                const parsePrevReservationUrl = new URL(prevReservationUrl);
+                const prevReservationUrlParams = new URLSearchParams(parsePrevReservationUrl.search);
+                prevReservationUrlParams.set('dest', dest);
+                prevReservationUrl = `${parsePrevReservationUrl.origin}${parsePrevReservationUrl.port}${parsePrevReservationUrl.pathname}?${prevReservationUrlParams.toString()}`;
+                // reset the updated url in storage
+                localStorage.setItem('shrub:buyMatic:reservationUrl', prevReservationUrl);
+            }
+            return window.location.href = prevReservationUrl;
+        }
+        // otherwise get a new checkout url and set the url and reservation date in the storage
+        try {
+            const response = await axios.post(`${process.env.REACT_APP_API_ENDPOINT}/wyre/checkout`, params);
+            if (response?.data?.data?.url) {
+                localStorage.setItem('shrub:buyMatic:reservationUrl', response.data.data.url);
+                localStorage.setItem('shrub:buyMatic:reservationDate', new Date().toISOString());
+                // go to the  wyre checkout link and let it redirect back to the application on success/fail
+                return window.location.href = response.data.data.url;
+            }
+            throw new Error('could not retrieve checkout url');
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
+    return <>
+        <Button
+            pr={5}
+            d={{ base: "none", sm: "flex" }}
+            fontSize={"sm"}
+            variant={"link"}
+            colorScheme={"purple"}
+            rounded={"full"}
+            onClick={wyreCheckout}
+        >
+            Buy Matic
+        </Button>
+    </>
+}
+
+export default BuyMatic;

--- a/packages/gardens/src/components/BuyMatic.tsx
+++ b/packages/gardens/src/components/BuyMatic.tsx
@@ -1,74 +1,103 @@
 import axios from "axios";
-import {
-    Button,
-} from "@chakra-ui/react";
+import { Button } from "@chakra-ui/react";
 import { useWeb3React } from "@web3-react/core";
 
 // TODO: could update source currency automatically based on locale
 
 function BuyMatic() {
-    const { account } = useWeb3React();
+  const { account } = useWeb3React();
 
-    async function wyreCheckout() {
-        type WyreCheckoutParams = {
-            redirectUrl?: string;
-            failureRedirectUrl?: string;
-            dest?: string | undefined;
-        }
-        const params: WyreCheckoutParams = {
-            redirectUrl: window.location.href,
-            failureRedirectUrl: window.location.href,
-        };
-        let dest;
-        if (account) {
-            dest = `ethereum:${account}`;
-            params.dest = dest;
-        }
-        let prevReservationUrl = localStorage.getItem('shrub:buyMatic:reservationUrl');
-        const prevReservationDate = localStorage.getItem('shrub:buyMatic:reservationDate');
-        const prevReservationEndDate = prevReservationDate && new Date((new Date(prevReservationDate).getTime() + (60 * 1000 * 14)));
-        // if there is a reservation in the storage and we are within the range, use previous reservation url
-        if (prevReservationDate && prevReservationEndDate && (prevReservationEndDate > new Date()) && prevReservationUrl){
-            // go to the previously used wyre checkout link and let it redirect back to the application on success/fail
-            // reset the ethereum address in the reservation url if a user has updated it
-            if (account && dest && !prevReservationUrl.includes(account)) {
-                const parsePrevReservationUrl = new URL(prevReservationUrl);
-                const prevReservationUrlParams = new URLSearchParams(parsePrevReservationUrl.search);
-                prevReservationUrlParams.set('dest', dest);
-                prevReservationUrl = `${parsePrevReservationUrl.origin}${parsePrevReservationUrl.port}${parsePrevReservationUrl.pathname}?${prevReservationUrlParams.toString()}`;
-                // reset the updated url in storage
-                localStorage.setItem('shrub:buyMatic:reservationUrl', prevReservationUrl);
-            }
-            return window.location.href = prevReservationUrl;
-        }
-        // otherwise get a new checkout url and set the url and reservation date in the storage
-        try {
-            const response = await axios.post(`${process.env.REACT_APP_API_ENDPOINT}/wyre/checkout`, params);
-            if (response?.data?.data?.url) {
-                localStorage.setItem('shrub:buyMatic:reservationUrl', response.data.data.url);
-                localStorage.setItem('shrub:buyMatic:reservationDate', new Date().toISOString());
-                // go to the  wyre checkout link and let it redirect back to the application on success/fail
-                return window.location.href = response.data.data.url;
-            }
-            throw new Error('could not retrieve checkout url');
-        } catch (err) {
-            console.error(err);
-        }
+  async function wyreCheckout() {
+    type WyreCheckoutParams = {
+      redirectUrl?: string;
+      failureRedirectUrl?: string;
+      dest?: string | undefined;
+    };
+    const params: WyreCheckoutParams = {
+      redirectUrl: window.location.href,
+      failureRedirectUrl: window.location.href,
+    };
+    let dest;
+    if (account) {
+      dest = `ethereum:${account}`;
+      params.dest = dest;
     }
+    let prevReservationUrl = localStorage.getItem(
+      "shrub:buyMatic:reservationUrl"
+    );
+    const prevReservationDate = localStorage.getItem(
+      "shrub:buyMatic:reservationDate"
+    );
+    const prevReservationEndDate =
+      prevReservationDate &&
+      new Date(new Date(prevReservationDate).getTime() + 60 * 1000 * 14);
+    // if there is a reservation in the storage and we are within the range, use previous reservation url
+    if (
+      prevReservationDate &&
+      prevReservationEndDate &&
+      prevReservationEndDate > new Date() &&
+      prevReservationUrl
+    ) {
+      // go to the previously used wyre checkout link and let it redirect back to the application on success/fail
+      // reset the ethereum address in the reservation url if a user has updated it
+      if (account && dest && !prevReservationUrl.includes(account)) {
+        const parsePrevReservationUrl = new URL(prevReservationUrl);
+        const prevReservationUrlParams = new URLSearchParams(
+          parsePrevReservationUrl.search
+        );
+        prevReservationUrlParams.set("dest", dest);
+        prevReservationUrl = `${parsePrevReservationUrl.origin}${
+          parsePrevReservationUrl.port
+        }${
+          parsePrevReservationUrl.pathname
+        }?${prevReservationUrlParams.toString()}`;
+        // reset the updated url in storage
+        localStorage.setItem(
+          "shrub:buyMatic:reservationUrl",
+          prevReservationUrl
+        );
+      }
+      return (window.location.href = prevReservationUrl);
+    }
+    // otherwise get a new checkout url and set the url and reservation date in the storage
+    try {
+      const response = await axios.post(
+        `${process.env.REACT_APP_API_ENDPOINT}/wyre/checkout`,
+        params
+      );
+      if (response?.data?.data?.url) {
+        localStorage.setItem(
+          "shrub:buyMatic:reservationUrl",
+          response.data.data.url
+        );
+        localStorage.setItem(
+          "shrub:buyMatic:reservationDate",
+          new Date().toISOString()
+        );
+        // go to the  wyre checkout link and let it redirect back to the application on success/fail
+        return (window.location.href = response.data.data.url);
+      }
+      throw new Error("could not retrieve checkout url");
+    } catch (err) {
+      console.error(err);
+    }
+  }
 
-    return <>
-        <Button
-            pr={5}
-            d={{ base: "none", sm: "flex" }}
-            fontSize={"sm"}
-            variant={"link"}
-            colorScheme={"purple"}
-            rounded={"full"}
-            onClick={wyreCheckout}
-        >
-            Buy Matic
-        </Button>
+  return (
+    <>
+      <Button
+        pr={5}
+        display={{ base: "none", sm: "flex" }}
+        fontSize={"sm"}
+        variant={"link"}
+        colorScheme={"purple"}
+        rounded={"full"}
+        onClick={wyreCheckout}
+      >
+        {account ? "Buy MATIC" : ""}
+      </Button>
     </>
+  );
 }
 
 export default BuyMatic;

--- a/packages/gardens/src/components/TopNav.tsx
+++ b/packages/gardens/src/components/TopNav.tsx
@@ -102,8 +102,12 @@ function TopNav() {
           <Flex alignItems={"center"}>
             {!isMobile && (
               <>
-                <BuyMatic></BuyMatic>
-                <Box pr={5} d={{ base: "none", sm: "flex" }} size={buttonSize}>
+                <BuyMatic />
+                <Box
+                  pr={5}
+                  display={{ base: "none", sm: "flex" }}
+                  size={buttonSize}
+                >
                   <Balance />
                 </Box>
               </>

--- a/packages/gardens/src/components/TopNav.tsx
+++ b/packages/gardens/src/components/TopNav.tsx
@@ -31,6 +31,7 @@ import {
   ConnectWalletModal,
   getErrorMessage,
 } from "./ConnectWallet";
+import BuyMatic from "./BuyMatic";
 import { useConnectWallet } from "../hooks/useConnectWallet";
 import { TxContext } from "./Store";
 import { confirmingCount, TxStatusList } from "./TxMonitoring";
@@ -100,11 +101,13 @@ function TopNav() {
 
           <Flex alignItems={"center"}>
             {!isMobile && (
-              <Box pr={5} d={{ base: "none", sm: "flex" }} size={buttonSize}>
-                <Balance />
-              </Box>
+              <>
+                <BuyMatic></BuyMatic>
+                <Box pr={5} d={{ base: "none", sm: "flex" }} size={buttonSize}>
+                  <Balance />
+                </Box>
+              </>
             )}
-
             <Box onClick={onOpen} mr={isMobile ? "19.5" : "0"}>
               {/*connect wallet button*/}
               <Button


### PR DESCRIPTION
- Adds a BuyMatic Component that is essentially a Button with onClick handler that will call a separate integration api via env variable `REACT_APP_API_ENDPOINT` and an appended Wyre checkout path.
- Uses local storage to set the Wyre order reservation url and reuse it if within 14 min of date record
- Auto fill the Ethereum address in the checkout ui if it exists in web3 provider
- Only allow MATIC purchase
- Redirect to current url on checkout success and failure case